### PR TITLE
Fix: recover streaming response when app returns from background (#20)

### DIFF
--- a/shamelagpt-android/app/src/main/java/com/shamelagpt/android/presentation/chat/ChatScreen.kt
+++ b/shamelagpt-android/app/src/main/java/com/shamelagpt/android/presentation/chat/ChatScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Psychology
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -83,6 +84,20 @@ fun ChatScreen(
     // Load conversation when composable is first created
     LaunchedEffect(conversationId) {
         viewModel.loadConversation(conversationId)
+    }
+
+    // Recover streaming response when app returns from background
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            when (event) {
+                androidx.lifecycle.Lifecycle.Event.ON_PAUSE -> viewModel.onAppBackgrounded()
+                androidx.lifecycle.Lifecycle.Event.ON_RESUME -> viewModel.onAppResumed()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     // Consume one-shot share payload (if app was opened via Android share sheet).

--- a/shamelagpt-android/app/src/main/java/com/shamelagpt/android/presentation/chat/ChatViewModel.kt
+++ b/shamelagpt-android/app/src/main/java/com/shamelagpt/android/presentation/chat/ChatViewModel.kt
@@ -75,6 +75,10 @@ class ChatViewModel(
     private var messageCollectionJob: Job? = null
     private var activeConversationLoadId: String? = null
 
+    // Track if streaming was interrupted by app backgrounding
+    private var streamInterrupted = false
+    private var interruptedConversationId: String? = null
+
     /**
      * Loads a conversation by ID.
      * If conversationId is null, starts a new conversation.
@@ -452,6 +456,43 @@ class ChatViewModel(
                 ChatFlowDiagnostics.clear(detail = "chat.send.error")
             }
         }
+    }
+
+    /**
+     * Called when the app goes to background during streaming.
+     * Marks the stream as interrupted so we can recover on resume.
+     */
+    fun onAppBackgrounded() {
+        if (_uiState.value.isLoading || _uiState.value.streamingMessage != null) {
+            streamInterrupted = true
+            interruptedConversationId = _uiState.value.conversationId
+            Logger.i(TAG, "Stream interrupted by backgrounding, conversationId=${Logger.redactedId(interruptedConversationId)}")
+        }
+    }
+
+    /**
+     * Called when the app returns from background.
+     * If streaming was interrupted, reload the conversation to recover the saved response.
+     */
+    fun onAppResumed() {
+        if (!streamInterrupted) return
+        streamInterrupted = false
+        val conversationId = interruptedConversationId ?: return
+        interruptedConversationId = null
+
+        Logger.i(TAG, "Recovering interrupted stream for conversationId=${Logger.redactedId(conversationId)}")
+
+        // Clear streaming state
+        _uiState.update { state ->
+            state.copy(
+                isLoading = false,
+                streamingMessage = null,
+                thinkingMessages = emptyList()
+            )
+        }
+
+        // Reload conversation from backend to get the saved partial/full response
+        loadConversation(conversationId, showHydrationUi = false)
     }
 
     /**


### PR DESCRIPTION
## Problem

When a user switches to another app or the device goes to sleep while a streaming response is in progress, the SSE connection drops. The user returns to an incomplete or stuck chat.

## Fix

- Added `onAppBackgrounded()` and `onAppResumed()` methods to ChatViewModel
- `onAppBackgrounded`: Detects if streaming was active and marks it as interrupted
- `onAppResumed`: If stream was interrupted, clears streaming state and reloads the conversation from the backend to recover the saved response
- Added `LifecycleEventObserver` in ChatScreen to call these on ON_PAUSE/ON_RESUME

## How it works

1. User sends question, streaming starts
2. User switches to another app → ON_PAUSE fires → `onAppBackgrounded()` saves the interrupted state
3. Backend detects disconnect, saves partial response to database
4. User returns to app → ON_RESUME fires → `onAppResumed()` reloads conversation
5. Saved response is displayed from the backend data

Closes #20