### PR TITLE
Add Apple Sign-In to iOS app

### DIFF
--- a/shamelagpt-ios/shamelagpt/Core/Networking/APIClient.swift
+++ b/shamelagpt-ios/shamelagpt/Core/Networking/APIClient.swift
@@ -18,6 +18,7 @@ protocol APIClientProtocol {
     func login(_ request: LoginRequest) async throws -> AuthResponse
     func forgotPassword(_ email: String) async throws
     func googleSignIn(_ request: GoogleSignInRequest) async throws -> AuthResponse
+    func appleSignIn(_ request: AppleSignInRequest) async throws -> AuthResponse
     func refreshToken(_ request: RefreshTokenRequest) async throws -> AuthResponse
     func getCurrentUser() async throws -> UserResponse
     func updateCurrentUser(_ request: UpdateUserRequest) async throws -> UserResponse
@@ -176,6 +177,12 @@ final class APIClient: APIClientProtocol {
     /// Google Sign-In
     func googleSignIn(_ request: GoogleSignInRequest) async throws -> AuthResponse {
         let endpoint = baseURL.appendingPathComponent("api/auth/google")
+        return try await performRequest(url: endpoint, method: "POST", body: request)
+    }
+
+    /// Apple Sign-In
+    func appleSignIn(_ request: AppleSignInRequest) async throws -> AuthResponse {
+        let endpoint = baseURL.appendingPathComponent("api/auth/apple")
         return try await performRequest(url: endpoint, method: "POST", body: request)
     }
 
@@ -585,6 +592,10 @@ final class PreviewMockAPIClient: APIClientProtocol {
     }
 
     func googleSignIn(_ request: GoogleSignInRequest) async throws -> AuthResponse {
+        return mockAuthResponse
+    }
+
+    func appleSignIn(_ request: AppleSignInRequest) async throws -> AuthResponse {
         return mockAuthResponse
     }
 

--- a/shamelagpt-ios/shamelagpt/Core/Networking/Models/AppleSignInRequest.swift
+++ b/shamelagpt-ios/shamelagpt/Core/Networking/Models/AppleSignInRequest.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct AppleSignInRequest: Encodable {
+    let idToken: String
+}

--- a/shamelagpt-ios/shamelagpt/Data/Repositories/AuthRepositoryImpl.swift
+++ b/shamelagpt-ios/shamelagpt/Data/Repositories/AuthRepositoryImpl.swift
@@ -67,6 +67,19 @@ final class AuthRepositoryImpl: AuthRepository {
         }
     }
 
+    func appleSignIn(request: AppleSignInRequest) async throws -> AuthResponse {
+        do {
+            AppLogger.auth.logDebug("apple sign-in request started")
+            let response = try await apiClient.appleSignIn(request)
+            persistSession(from: response)
+            AppLogger.auth.logInfo("apple sign-in request succeeded")
+            return response
+        } catch {
+            AppLogger.auth.logWarning("apple sign-in request failed reason=\(type(of: error))")
+            throw normalizeError(error)
+        }
+    }
+
     func refreshToken(request: RefreshTokenRequest) async throws -> AuthResponse {
         do {
             AppLogger.auth.logInfo("refresh token request started")

--- a/shamelagpt-ios/shamelagpt/Domain/Repositories/AuthRepository.swift
+++ b/shamelagpt-ios/shamelagpt/Domain/Repositories/AuthRepository.swift
@@ -12,6 +12,7 @@ protocol AuthRepository {
     func login(request: LoginRequest) async throws -> AuthResponse
     func forgotPassword(email: String) async throws
     func googleSignIn(request: GoogleSignInRequest) async throws -> AuthResponse
+    func appleSignIn(request: AppleSignInRequest) async throws -> AuthResponse
     func refreshToken(request: RefreshTokenRequest) async throws -> AuthResponse
     func getCurrentUser() async throws -> UserResponse
     func updateCurrentUser(request: UpdateUserRequest) async throws -> UserResponse

--- a/shamelagpt-ios/shamelagpt/Presentation/Scenes/Auth/AuthView.swift
+++ b/shamelagpt-ios/shamelagpt/Presentation/Scenes/Auth/AuthView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AuthenticationServices
 
 struct AuthView: View {
     @ObservedObject var viewModel: AuthViewModel
@@ -79,6 +80,44 @@ struct AuthView: View {
             .buttonStyle(.secondary)
             .disabled(viewModel.isLoading)
             .accessibilityIdentifier(AccessibilityID.Auth.continueAsGuestButton)
+
+            // Divider
+            HStack {
+                Rectangle().frame(height: 1).foregroundColor(DesignSystem.Colors.textSecondary(colorScheme).opacity(0.3))
+                Text("OR")
+                    .font(DesignSystem.Typography.footnote)
+                    .foregroundColor(DesignSystem.Colors.textSecondary(colorScheme))
+                Rectangle().frame(height: 1).foregroundColor(DesignSystem.Colors.textSecondary(colorScheme).opacity(0.3))
+            }
+            .padding(.vertical, DesignSystem.Spacing.xs)
+
+            // Apple Sign-In button
+            SignInWithAppleButton(
+                viewModel.isLoginMode ? .signIn : .signUp,
+                onRequest: { request in
+                    request.requestedScopes = [.fullName, .email]
+                },
+                onCompletion: { result in
+                    switch result {
+                    case .success(let authorization):
+                        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                           let identityTokenData = appleIDCredential.identityToken,
+                           let idToken = String(data: identityTokenData, encoding: .utf8) {
+                            viewModel.appleSignIn(idToken: idToken, onSuccess: onAuthenticated)
+                        } else {
+                            viewModel.errorMessage = "Failed to get Apple ID token"
+                        }
+                    case .failure(let error):
+                        if (error as NSError).code != ASAuthorizationError.canceled.rawValue {
+                            viewModel.errorMessage = error.localizedDescription
+                        }
+                    }
+                }
+            )
+            .signInWithAppleButtonStyle(colorScheme == .dark ? .white : .black)
+            .frame(height: 50)
+            .cornerRadius(DesignSystem.CornerRadius.md)
+            .disabled(viewModel.isLoading)
 
             // Toggle mode link
             Button {

--- a/shamelagpt-ios/shamelagpt/Presentation/Scenes/Auth/AuthViewModel.swift
+++ b/shamelagpt-ios/shamelagpt/Presentation/Scenes/Auth/AuthViewModel.swift
@@ -111,4 +111,23 @@ final class AuthViewModel: ObservableObject {
             }
         }
     }
+
+    func appleSignIn(idToken: String, onSuccess: @escaping () -> Void) {
+        Task {
+            isLoading = true
+            errorMessage = nil
+            do {
+                AppLogger.auth.logInfo("apple sign-in request started")
+                _ = try await authRepository.appleSignIn(request: AppleSignInRequest(idToken: idToken))
+                isLoading = false
+                AppLogger.auth.logInfo("apple sign-in success")
+                onSuccess()
+            } catch {
+                isLoading = false
+                AppLogger.auth.logWarning("apple sign-in failed reason=\(type(of: error))")
+                AppLogger.auth.logError("apple sign-in error", error: error)
+                errorMessage = error.userFacingMessage
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Add native Sign in with Apple to the iOS app, matching the existing Google Sign-In pattern.

**Changes across all layers:**
- `AppleSignInRequest.swift` — new model (mirrors GoogleSignInRequest)
- `APIClientProtocol` + `APIClient` — added `appleSignIn()` calling `POST /api/auth/apple`
- `AuthRepository` + `AuthRepositoryImpl` — added `appleSignIn()` with session persistence
- `AuthViewModel` — added `appleSignIn(idToken:onSuccess:)`
- `AuthView` — native `SignInWithAppleButton` using AuthenticationServices framework

## Backend dependency

Backend endpoint `POST /api/auth/apple` is ready: https://github.com/Neura-Lines/shamela-qa-rag/pull/59

## How it works

1. User taps "Sign in with Apple" button
2. iOS presents native Apple auth sheet via AuthenticationServices
3. On success, extracts identity token from ASAuthorizationAppleIDCredential
4. Sends token to backend `POST /api/auth/apple`
5. Backend exchanges for Firebase token, creates/updates user, returns auth response
6. Session persisted locally, same as Google/email flows