### PR TITLE
fix: tolerate unknown SSE event types in chat stream (Android + iOS)

### DIFF
--- a/shamelagpt-android/app/src/main/java/com/shamelagpt/android/data/remote/datasource/ChatRemoteDataSourceImpl.kt
+++ b/shamelagpt-android/app/src/main/java/com/shamelagpt/android/data/remote/datasource/ChatRemoteDataSourceImpl.kt
@@ -217,11 +217,15 @@ class ChatRemoteDataSourceImpl(
                 code = "E-CHAT-STREAM-BACKEND",
                 message = event.message ?: event.error ?: event.content ?: "Backend stream error"
             )
-            else -> throw ChatOperationException(
-                operation = ChatOperation.SEND_MESSAGE,
-                code = "E-CHAT-STREAM-UNKNOWN",
-                message = "Unknown stream event type '${event.type}' in $raw"
-            )
+            else -> {
+                // Forward-compatible: silently ignore unknown event types.
+                // Backend adds new SSE event types over time (e.g. "title" in
+                // shamela-qa-rag#72, "fact_check_result" in fact-check mode);
+                // throwing here surfaced them as E-CHAT-STREAM-UNKNOWN and broke
+                // every new-conversation send. iOS does the same in
+                // StreamingMessageHandler.swift. Log so we notice new types.
+                Log.d(TAG, "Ignoring unknown stream event type '${event.type}' (raw='${raw.take(120)}')")
+            }
         }
     }
 

--- a/shamelagpt-android/app/src/main/java/com/shamelagpt/android/presentation/chat/ChatViewModel.kt
+++ b/shamelagpt-android/app/src/main/java/com/shamelagpt/android/presentation/chat/ChatViewModel.kt
@@ -473,11 +473,12 @@ class ChatViewModel(
                             )
                         }
                         else -> {
-                            throw ChatOperationException(
-                                operation = ChatOperation.SEND_MESSAGE,
-                                code = "E-CHAT-STREAM-UNKNOWN",
-                                message = "Unknown stream event type '${event.type}'"
-                            )
+                            // Forward-compatible: silently ignore unknown event
+                            // types. See ChatRemoteDataSourceImpl.validateStreamEvent
+                            // for context — new SSE event types from the backend
+                            // (e.g. "title", "fact_check_result") used to crash
+                            // every new-conversation send with E-CHAT-STREAM-UNKNOWN.
+                            Logger.d(TAG, "Ignoring unknown stream event type '${event.type}'")
                         }
                     }
                 }

--- a/shamelagpt-ios/shamelagpt/Core/Networking/StreamingMessageHandler.swift
+++ b/shamelagpt-ios/shamelagpt/Core/Networking/StreamingMessageHandler.swift
@@ -160,12 +160,13 @@ class StreamingMessageHandler: StreamingMessageHandlerProtocol {
                 description: rawEvent.message ?? rawEvent.error ?? rawEvent.content ?? "Backend stream error"
             )
         default:
-            throw ChatOperationException(
-                operation: .sendMessage,
-                code: "E-CHAT-STREAM-UNKNOWN",
-                retryable: true,
-                description: "Unknown stream event type '\(rawEvent.type)'"
-            )
+            // Forward-compatible: silently ignore unknown event types.
+            // Backend adds new SSE event types over time (e.g. "title" from
+            // shamela-qa-rag#72, "fact_check_result" in fact-check mode);
+            // throwing here surfaced them as E-CHAT-STREAM-UNKNOWN and broke
+            // every new-conversation send. Android mirrors this in
+            // ChatRemoteDataSourceImpl.validateStreamEvent.
+            AppLogger.network.logDebug("Ignoring unknown stream event type '\(rawEvent.type)'")
         }
     }
 }


### PR DESCRIPTION
## Summary

Chat-stream SSE parser on both mobile clients was a strict allowlist (`metadata` / `thinking` / `chunk` / `done` / `error`). Anything else threw `E-CHAT-STREAM-UNKNOWN` and surfaced as a generic "We could not send your message" toast to the user.

The backend has been adding new SSE event types over time without bumping a contract version:

- `title` — emitted mid-stream for new conversations (`shamela-qa-rag#72`, deployed 2026-06-02). Broke every first message in a brand-new chat.
- `fact_check_result` — emitted in fact-check mode. Breaks every claim verification.
- `cancelled` — emitted by `/chat/confirm-factcheck` on user cancel.

After the title-on-wire deploy today, prod users hit the toast on "Hi" because the backend now emits `{type:"title"}` between the chunks and `{type:"done"}` for new chats:

```
data: {"type":"metadata",…}
data: {"type":"thinking",…}     ← many
data: {"type":"chunk",…}        ← many
data: {"type":"title","title":"Greeting"}   ← NEW — Android/iOS throw here
data: {"type":"done",…}
```

Screenshot from prod that triggered this PR — note the bold `Error code: E-CHAT-STREAM-UNKNOWN`.

## What changed

Switch the "unknown event type" branch from `throw` to a debug log in three places:

- `shamelagpt-android/.../ChatRemoteDataSourceImpl.kt` — `validateStreamEvent`
- `shamelagpt-android/.../presentation/chat/ChatViewModel.kt` — the `when (event.type) { else -> … }` block in the SSE collector
- `shamelagpt-ios/.../Core/Networking/StreamingMessageHandler.swift` — `yieldEvent` default

`"error"` events still throw so genuine backend errors are still surfaced. New event types we don't yet recognize are silently no-op'd and logged for visibility.

This is intentionally the minimal forward-compat patch — we can wire up `title` / `fact_check_result` to real UI handlers in a follow-up PR, but the immediate goal is to stop crashing the stream.

## Test plan

- [ ] Android: install patched build, send any message in a fresh conversation → message streams to completion with no toast.
- [ ] Android: in fact-check mode, send a claim → response streams; no `E-CHAT-STREAM-UNKNOWN` toast.
- [ ] iOS: same two flows.
- [ ] Regression: backend emits `{type:"error", ...}` → user still sees the error UI (verify via mock or by hitting an endpoint that errors mid-stream).